### PR TITLE
Support indexing by traditional characters

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,24 @@
-pkg := cedict
+# create minified entries:
+MINI ?= true
+# index by simplified characters, or traditional:
+SIMP ?= true
+
+ifeq ($(SIMP),true)
+	pkg := cedict-simp
+	simp_flag := simplified
+else
+	pkg := cedict-trad
+	simp_flag := no-simplified
+endif
+
+ifeq ($(MINI),true)
+	mini_flag := mini
+else
+	mini_flag := no-mini
+endif
+
 txt := cedict_1_0_ts_utf-8_mdbg.txt
 aim := $(pkg).index $(pkg).dict.dz
-
-# as brief as possible or not
-MINI ?= true
 
 .PHONY: all clean _clean
 
@@ -13,11 +28,7 @@ $(txt):
 	curl -LO https://www.mdbg.net/chinese/export/cedict/$(txt).gz && gzip -d $(txt).gz
 
 $(pkg).txt: $(txt)
-ifeq ($(MINI),true)
-	python ./$(pkg).py -i ./$(txt) -o $(pkg).txt
-else
-	python ./$(pkg).py -i ./$(txt) -o $(pkg).txt --no-mini
-endif
+	python ./cedict.py -i ./$(txt) -o $(pkg).txt --$(mini_flag) --$(simp_flag)
 
 $(aim) &: $(pkg).txt
 	dictfmt --utf8 --allchars -s CEDICT -u https://cc-cedict.org -j $(pkg) < ./$(pkg).txt && dictzip $(pkg).dict

--- a/README.md
+++ b/README.md
@@ -20,6 +20,26 @@ A port of [CC-CEDICT] database for Dictd.
 make && sudo make install
 ```
 
+### Options
+
+To make full dictionary entries:
+
+```bash
+MINI=false make && sudo make install
+```
+
+To make dictionary entries indexed by their traditional variant:
+
+```bash
+SIMP=false make && sudo SIMP=false make install
+```
+
+To install both full dictionaries at once:
+
+```bash
+MINI=false make && sudo make install && MINI=false SIMP=false make && sudo SIMP=false make install
+```
+
 ## [AUR](https://aur.archlinux.org/packages/dict-cedict-git/)
 
 ```bash
@@ -31,9 +51,9 @@ yay -S dict-cedict-git # for Arch-based distros
 Add these lines below to `/etc/dict/dictd.conf`:
 
 ```conf
-database cedict {
-data /usr/share/dict/cedict.dict.dz
-index /usr/share/dict/cedict.index
+database cedict-simp {
+data /usr/share/dict/cedict-simp.dict.dz
+index /usr/share/dict/cedict-simp.index
 }
 ```
 

--- a/cedict.py
+++ b/cedict.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# -*- coding: UTF-8 -*-
+# -*- coding: utf-8 -*-
 
 import argparse
 import textwrap as tp
@@ -14,9 +14,9 @@ tones = dict(a = ['a','ā','á','ǎ','à'],\
 def main():
     args = parser()
     if args.mini:
-        cedicts(args.input, args.output)
+        cedicts(args.input, args.output, args.simplified)
     else:
-        cedict(args.input, args.output)
+        cedict(args.input, args.output, args.simplified)
 
 def parser():
     agp = argparse.ArgumentParser()
@@ -24,6 +24,8 @@ def parser():
     agp.add_argument('-o', '--output', help='specify the output file')
     agp.add_argument('-m', '--mini', default=True, action=argparse.BooleanOptionalAction,
                      help='keep words and their definitions only')
+    agp.add_argument('-s', '--simplified', default=True, action=argparse.BooleanOptionalAction,
+                     help='index by simplified characters')
     return agp.parse_args()
 
 def index(pin):
@@ -41,31 +43,43 @@ def tone(pin):
     pins[idx] = tones[pins[idx]][int(pins[-1]) % 5]
     return ''.join(pins[:-1])
 
-def cedicts(ifile, ofile):
+def cedicts(ifile, ofile, simplified):
     with open(ifile) as f:
         with open(ofile, 'w') as g:
             for l in f:
                 if l[0] == '#': continue
                 ws = l.split(' ', 2)
-                g.write(':' + ws[1] + ':\n')
+                if simplified:
+                    head = ws[1]
+                else:
+                    head = ws[0]
+                g.write(':' + head + ':\n')
                 a = (ws[2].replace('] /', ']⋄/').split('⋄'))[1][1:-2].split('/')
                 for i in range(len(a)):
                     g.write('\n'.join(list(tp.wrap(a[i], 64))) + '\n')
 
-def cedict(ifile, ofile):
+def cedict(ifile, ofile, simplified):
     with open(ifile) as f:
         with open(ofile, 'w') as g:
             for l in f:
                 if l[0] == '#': continue
                 ws = l.split(' ', 2)
-                g.write(':' + ws[1] + ':\n')
+                if simplified:
+                    head = ws[1]
+                    tail = ws[0]
+                    tail_label = '[T] '
+                else:
+                    head = ws[0]
+                    tail = ws[1]
+                    tail_label = '[S] '
+                g.write(':' + head + ':\n')
                 t = ws[2].replace('] /', ']⋄/').split('⋄')
                 g.write('[P] ' + ' '.join(map(tone, t[0][1:-1].split(' '))) + '\n')
                 a = t[1][1:-2].split('/')
                 for i in range(len(a)):
                     b = ('\n    ' if len(a) == 1 else '\n      ').join(list(tp.wrap(a[i], 64)))
                     g.write((('[E] ' if len(a) == 1 else '[E] - ') if i == 0 else '    - ') + b + '\n')
-                g.write('[T] ' + ws[0] + '\n')
+                g.write(tail_label + tail + '\n')
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
SIMP=false given to the make script creates a cedict-trad dictionary and installs it alongside the default simplified version.

also documents the MINI=false option in the README.

NOTE: this will now name the default dictd dictionary "cedict-simp", which seems acceptable, since CEDICT is actually agnostic about it and lists traditional first.